### PR TITLE
Make Renovate pin versions for more reproducible builds

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "rangeStrategy": "pin",
+  "docker": {
+    "pinDigests": true
+  },
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "enabled": true
+    }
   ]
 }


### PR DESCRIPTION
* Set `rangeStrategy` to `"pin"` to ensure all dependencies are locked to specific versions.
* Added a `docker` configuration block with `pinDigests: true` to guarantee Docker images are referenced by immutable digests.
* Introduced a `packageRules` entry to explicitly enable updates for Docker dependencies across all update types (major, minor, patch).