### PR TITLE
Ignore digest pinning for my images generated by GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>c-gerke/renovate-config"
+  "extends": ["github>c-gerke/renovate-config"],
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^ghcr\\.io/oct8l/"],
+      "pinDigests": false
+    }
   ]
 }


### PR DESCRIPTION
These images need to specifically use the `latest` tag because this is what the workflow depends on.