### PR TITLE
Pin Trivy version digest

### DIFF
--- a/.github/workflows/test-scheduled-functionality.yml
+++ b/.github/workflows/test-scheduled-functionality.yml
@@ -19,6 +19,7 @@ on:
 env:
   REGISTRY: ghcr.io/${{ github.repository_owner }}
   TEST_TAG: pre-release-test-${{ github.run_number }}
+  TRIVY_VERSION: v0.69.3
 
 jobs:
   pre-build-test:
@@ -202,8 +203,9 @@ jobs:
         run: |
           echo "Running security scans on test images..."
 
-          # Install Trivy for vulnerability scanning
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp/trivy
+          TRIVY_VER="${TRIVY_VERSION#v}"
+          curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/trivy_${TRIVY_VER}_Linux-64bit.tar.gz" -o /tmp/trivy.tgz
+          tar -xzf /tmp/trivy.tgz -C /tmp
 
           # Scan key images
           scan_passed=true
@@ -215,7 +217,7 @@ jobs:
 
           for image in "${images[@]}"; do
             echo "Scanning $image..."
-            /tmp/trivy/trivy image --exit-code 1 --severity HIGH,CRITICAL --quiet $image
+            /tmp/trivy image --exit-code 1 --severity HIGH,CRITICAL --quiet $image
             if [ $? -ne 0 ]; then
               echo "❌ Security scan failed for $image"
               scan_passed=false

--- a/renovate.json
+++ b/renovate.json
@@ -19,12 +19,14 @@
   ],
   "packageRules": [
     {
+      "description": "Images built from this repo — do not pin digests",
       "matchDatasources": [
         "docker"
       ],
       "matchPackageNames": [
-        "/^ghcr\\.io/oct8l//"
-      ]
+        "/^ghcr\\.io\\/oct8l\\/lancache/"
+      ],
+      "pinDigests": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,25 @@
   "extends": [
     "github>c-gerke/renovate-config"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Trivy CLI pinned in scheduled workflow",
+      "fileMatch": [
+        "^\\.github/workflows/test-scheduled-functionality\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "TRIVY_VERSION:\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasource": "github-releases",
+      "packageName": "aquasecurity/trivy"
+    }
+  ],
   "packageRules": [
     {
       "matchDatasources": [
         "docker"
       ],
-      "pinDigests": false,
       "matchPackageNames": [
         "/^ghcr\\.io/oct8l//"
       ]


### PR DESCRIPTION
This pull request improves the Trivy vulnerability scanning process in the `test-scheduled-functionality.yml` workflow and adds automated dependency management for the Trivy CLI version. The main focus is on making the Trivy version explicit, ensuring it can be updated automatically, and improving how Trivy is installed and invoked in CI.

**Workflow and Dependency Management Improvements:**

* Explicitly sets the `TRIVY_VERSION` environment variable in `.github/workflows/test-scheduled-functionality.yml`, making the Trivy version used by the workflow clear and configurable.
* Updates the Trivy installation step in the workflow to download and extract the specified version directly from GitHub releases, rather than using the install script, providing more control and reliability.
* Updates the Trivy invocation to use the extracted binary path, reflecting the new installation method.

**Automated Dependency Updates:**

* Adds a `customManagers` entry to `renovate.json` to detect and update the `TRIVY_VERSION` in the workflow file automatically using Renovate, ensuring the workflow always uses the latest secure version of Trivy.