### PR TITLE
CI: add static validation gate (actionlint, ShellCheck, Compose, Renovate) and least-privilege permissions

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# Agreed ShellCheck severity for CI: info/style findings are advisory and do not
+# fail validation. warning/error findings (real bugs) still fail the build.
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      - 'shellcheck reported issue in this script: SC[0-9]+:info:.+'
+      - 'shellcheck reported issue in this script: SC[0-9]+:style:.+'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,18 @@ on:
   schedule:
     - cron: '30 4 1,15 * *'
 
+permissions:
+  contents: read
+
 jobs:
 
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
 
     steps:
 

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -30,10 +30,15 @@ on:
 env:
   REGISTRY: ghcr.io/${{ github.repository_owner }}
 
+permissions:
+  contents: read
+
 jobs:
   performance-test:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,11 +9,18 @@ env:
   REGISTRY: ghcr.io/${{ github.repository_owner }}
   PR_TAG: pr-${{ github.event.pull_request.number }}
 
+permissions:
+  contents: read
+
 jobs:
 
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
 
     steps:
 

--- a/.github/workflows/test-pr-functionality.yml
+++ b/.github/workflows/test-pr-functionality.yml
@@ -9,9 +9,16 @@ env:
   REGISTRY: ghcr.io/${{ github.repository_owner }}
   PR_TAG: pr-${{ github.event.pull_request.number }}
 
+permissions:
+  contents: read
+
 jobs:
   wait-for-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      contents: read
+      checks: read
     steps:
       - name: Wait for PR build to complete
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -62,6 +69,9 @@ jobs:
   functional-test-amd64:
     needs: wait-for-build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
     strategy:
       matrix:
         test-scenario:
@@ -259,6 +269,9 @@ jobs:
   functional-test-arm64:
     needs: wait-for-build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -347,6 +360,9 @@ jobs:
   test-summary:
     needs: [functional-test-amd64, functional-test-arm64]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
     if: always()
     steps:
       - name: Test Results Summary

--- a/.github/workflows/test-scheduled-functionality.yml
+++ b/.github/workflows/test-scheduled-functionality.yml
@@ -21,9 +21,16 @@ env:
   TEST_TAG: pre-release-test-${{ github.run_number }}
   TRIVY_VERSION: v0.72.0
 
+permissions:
+  contents: read
+
 jobs:
   pre-build-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
     outputs:
       should_proceed: ${{ steps.test_decision.outputs.proceed }}
       test_results: ${{ steps.test_summary.outputs.results }}
@@ -303,6 +310,10 @@ jobs:
   trigger-main-build:
     needs: pre-build-test
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: write
     if: needs.pre-build-test.outputs.should_proceed == 'true'
 
     steps:
@@ -331,6 +342,9 @@ jobs:
   notify-failure:
     needs: pre-build-test
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
     if: needs.pre-build-test.outputs.should_proceed != 'true'
 
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,66 @@
+name: Validate
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # rhysd/actionlint bundles a pinned ShellCheck build, so one image covers both checks.
+  ACTIONLINT_IMAGE: rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+  RENOVATE_IMAGE: renovate/renovate:43.270.1@sha256:6f215fca5f89bbc2b4bee880ffd9e5080f40eac592efa7d5572f03c7a4629308
+
+jobs:
+  validate:
+    name: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: "Lint workflows with actionlint (includes ShellCheck on run: steps)"
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/repo" -w /repo "${ACTIONLINT_IMAGE}" -color
+
+      - name: Validate docker-compose.yml
+        run: docker compose -f docker-compose.yml config -q
+
+      - name: Parse renovate.json with jq
+        run: jq empty renovate.json
+
+      - name: Validate renovate.json against schema
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/repo" -w /repo "${RENOVATE_IMAGE}" \
+            renovate-config-validator --strict renovate.json
+
+      - name: Check for whitespace and conflict-marker errors in the diff
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+
+          if [ -z "${base}" ] || ! git cat-file -e "${base}" 2>/dev/null; then
+            echo "No usable base revision for this event; skipping git diff --check"
+            exit 0
+          fi
+
+          git diff --check "${base}" "${{ github.sha }}"


### PR DESCRIPTION
## Summary

First PR in a planned series to make CI safe to gate merges on (dependency-update / Renovate PRs in particular). This PR only adds static validation and workflow hygiene; it does not change build/test orchestration yet.

- Adds `.github/workflows/validate.yml`, a new required-eligible job that runs on every PR and on push to `main`:
  - `actionlint` (containerized, pinned by digest) lints every workflow file, including embedded shell via its bundled ShellCheck.
  - `docker compose -f docker-compose.yml config -q` validates the repo's user-facing Compose file.
  - `jq empty renovate.json` confirms the file is valid JSON.
  - `renovate-config-validator --strict` (containerized, pinned by digest) validates `renovate.json` against the current Renovate schema.
  - `git diff --check` catches whitespace/conflict-marker errors introduced by the PR.
- Adds `.github/actionlint.yaml` documenting the agreed ShellCheck severity policy: info/style findings (mostly `SC2086` quoting suggestions) are advisory and ignored; warning/error findings still fail the job. No actual bugs were suppressed — the existing workflows only had info/style-level findings.
- Adds explicit `permissions:` blocks (workflow- and job-level) and `timeout-minutes` to `build.yml`, `pr-build.yml`, `test-pr-functionality.yml`, `test-scheduled-functionality.yml`, and `performance-tests.yml`, none of which previously declared permissions or bounded job runtime.

All validation tools run from pinned container images (by tag *and* digest) rather than ad hoc installs, so this PR doesn't introduce any new floating dependencies.

## Not in scope for this PR

- Consolidating the PR build/test workflows into a single `ci-gate` (planned next PR).
- Enabling branch protection (must wait until `ci-gate`, or this validate check, has a successful run history on `main`).
- Deeper functional/integration testing changes.

## Test plan

- [x] Ran actionlint, ShellCheck (via actionlint), `docker compose config`, `jq`, and `renovate-config-validator` locally via the same pinned container images against the current repo state — all pass.
- [x] Verified `renovate-config-validator` actually fails on a deliberately invalid config key (sanity check that the validator is wired correctly).
- [x] Confirm the new `validate` workflow run succeeds on this PR in GitHub Actions.