### PR TITLE
CI: share the GHCR registry build cache across build.yml and scheduled tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,14 +36,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Cache Docker layers
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to Github Packages
         if: github.event_name != 'pull_request'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -56,7 +48,10 @@ jobs:
         run: |
           git clone https://github.com/lancachenet/ubuntu.git
           cd ubuntu
-          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 -t ${{ env.REGISTRY }}/lancache-ubuntu --push .
+          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 \
+            --cache-from "type=registry,ref=${{ env.REGISTRY }}/lancache-ubuntu:buildcache" \
+            --cache-to "type=registry,ref=${{ env.REGISTRY }}/lancache-ubuntu:buildcache,mode=max" \
+            -t ${{ env.REGISTRY }}/lancache-ubuntu --push .
           cd ..
 
       - name: Build & Push lancachenet/ubuntu-nginx
@@ -66,7 +61,10 @@ jobs:
           line_number=$(grep -n "FROM lancachenet/ubuntu:latest" Dockerfile | cut -d: -f1)
           sed -i "${line_number}cFROM ${{ env.REGISTRY }}/lancache-ubuntu" Dockerfile
           cat Dockerfile
-          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 -t ${{ env.REGISTRY }}/lancache-ubuntu-nginx --push .
+          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 \
+            --cache-from "type=registry,ref=${{ env.REGISTRY }}/lancache-ubuntu-nginx:buildcache" \
+            --cache-to "type=registry,ref=${{ env.REGISTRY }}/lancache-ubuntu-nginx:buildcache,mode=max" \
+            -t ${{ env.REGISTRY }}/lancache-ubuntu-nginx --push .
           cd ..
 
       - name: Build & Push lancachenet/monolithic
@@ -77,7 +75,10 @@ jobs:
           sed -i "${line_number}cFROM ${{ env.REGISTRY }}/lancache-ubuntu-nginx" Dockerfile
           cat Dockerfile
           cp ../20_cache.conf overlay/etc/nginx/sites-available/cache.conf.d/root/20_cache.conf
-          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 -t ${{ env.REGISTRY }}/lancache-monolithic --push .
+          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 \
+            --cache-from "type=registry,ref=${{ env.REGISTRY }}/lancache-monolithic:buildcache" \
+            --cache-to "type=registry,ref=${{ env.REGISTRY }}/lancache-monolithic:buildcache,mode=max" \
+            -t ${{ env.REGISTRY }}/lancache-monolithic --push .
           cd ..
 
       - name: Build & Push lancachenet/generic
@@ -87,14 +88,20 @@ jobs:
           line_number=$(grep -n "FROM lancachenet/monolithic:latest" Dockerfile | cut -d: -f1)
           sed -i "${line_number}cFROM ${{ env.REGISTRY }}/lancache-monolithic" Dockerfile
           cat Dockerfile
-          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 -t ${{ env.REGISTRY }}/lancache-generic --push .
+          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 \
+            --cache-from "type=registry,ref=${{ env.REGISTRY }}/lancache-generic:buildcache" \
+            --cache-to "type=registry,ref=${{ env.REGISTRY }}/lancache-generic:buildcache,mode=max" \
+            -t ${{ env.REGISTRY }}/lancache-generic --push .
           cd ..
 
       - name: Build & Push lancachenet/sniproxy
         run: |
           git clone https://github.com/lancachenet/sniproxy.git
           cd sniproxy
-          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 -t ${{ env.REGISTRY }}/lancache-sniproxy --push .
+          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 \
+            --cache-from "type=registry,ref=${{ env.REGISTRY }}/lancache-sniproxy:buildcache" \
+            --cache-to "type=registry,ref=${{ env.REGISTRY }}/lancache-sniproxy:buildcache,mode=max" \
+            -t ${{ env.REGISTRY }}/lancache-sniproxy --push .
           cd ..
 
       - name: Build & Push lancachenet/lancache-dns
@@ -104,5 +111,8 @@ jobs:
           line_number=$(grep -n "FROM lancachenet/ubuntu:latest" Dockerfile | cut -d: -f1)
           sed -i "${line_number}cFROM ${{ env.REGISTRY }}/lancache-ubuntu" Dockerfile
           cat Dockerfile
-          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 -t ${{ env.REGISTRY }}/lancache-dns --push .
+          docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 \
+            --cache-from "type=registry,ref=${{ env.REGISTRY }}/lancache-dns:buildcache" \
+            --cache-to "type=registry,ref=${{ env.REGISTRY }}/lancache-dns:buildcache,mode=max" \
+            -t ${{ env.REGISTRY }}/lancache-dns --push .
           cd ..

--- a/.github/workflows/test-scheduled-functionality.yml
+++ b/.github/workflows/test-scheduled-functionality.yml
@@ -58,14 +58,20 @@ jobs:
           # Build just the key components for testing (faster than full build)
           git clone https://github.com/lancachenet/ubuntu.git
           cd ubuntu
-          docker buildx build --platform linux/amd64,linux/arm64 -t ${{ env.REGISTRY }}/lancache-ubuntu:${{ env.TEST_TAG }} --push .
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            --cache-from "type=registry,ref=${{ env.REGISTRY }}/lancache-ubuntu:buildcache" \
+            --cache-to "type=registry,ref=${{ env.REGISTRY }}/lancache-ubuntu:buildcache,mode=max" \
+            -t ${{ env.REGISTRY }}/lancache-ubuntu:${{ env.TEST_TAG }} --push .
           cd ..
 
           git clone https://github.com/lancachenet/ubuntu-nginx.git
           cd ubuntu-nginx
           line_number=$(grep -n "FROM lancachenet/ubuntu:latest" Dockerfile | cut -d: -f1)
           sed -i "${line_number}cFROM ${{ env.REGISTRY }}/lancache-ubuntu:${{ env.TEST_TAG }}" Dockerfile
-          docker buildx build --platform linux/amd64,linux/arm64 -t ${{ env.REGISTRY }}/lancache-ubuntu-nginx:${{ env.TEST_TAG }} --push .
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            --cache-from "type=registry,ref=${{ env.REGISTRY }}/lancache-ubuntu-nginx:buildcache" \
+            --cache-to "type=registry,ref=${{ env.REGISTRY }}/lancache-ubuntu-nginx:buildcache,mode=max" \
+            -t ${{ env.REGISTRY }}/lancache-ubuntu-nginx:${{ env.TEST_TAG }} --push .
           cd ..
 
           git clone https://github.com/lancachenet/monolithic.git
@@ -73,14 +79,20 @@ jobs:
           line_number=$(grep -n "FROM lancachenet/ubuntu-nginx:latest" Dockerfile | cut -d: -f1)
           sed -i "${line_number}cFROM ${{ env.REGISTRY }}/lancache-ubuntu-nginx:${{ env.TEST_TAG }}" Dockerfile
           cp ../20_cache.conf overlay/etc/nginx/sites-available/cache.conf.d/root/20_cache.conf
-          docker buildx build --platform linux/amd64,linux/arm64 -t ${{ env.REGISTRY }}/lancache-monolithic:${{ env.TEST_TAG }} --push .
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            --cache-from "type=registry,ref=${{ env.REGISTRY }}/lancache-monolithic:buildcache" \
+            --cache-to "type=registry,ref=${{ env.REGISTRY }}/lancache-monolithic:buildcache,mode=max" \
+            -t ${{ env.REGISTRY }}/lancache-monolithic:${{ env.TEST_TAG }} --push .
           cd ..
 
           git clone https://github.com/lancachenet/lancache-dns.git
           cd lancache-dns
           line_number=$(grep -n "FROM lancachenet/ubuntu:latest" Dockerfile | cut -d: -f1)
           sed -i "${line_number}cFROM ${{ env.REGISTRY }}/lancache-ubuntu:${{ env.TEST_TAG }}" Dockerfile
-          docker buildx build --platform linux/amd64,linux/arm64 -t ${{ env.REGISTRY }}/lancache-dns:${{ env.TEST_TAG }} --push .
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            --cache-from "type=registry,ref=${{ env.REGISTRY }}/lancache-dns:buildcache" \
+            --cache-to "type=registry,ref=${{ env.REGISTRY }}/lancache-dns:buildcache,mode=max" \
+            -t ${{ env.REGISTRY }}/lancache-dns:${{ env.TEST_TAG }} --push .
           cd ..
 
       - name: Test critical functionality

--- a/TESTING.md
+++ b/TESTING.md
@@ -74,6 +74,8 @@ build-candidates (same-repo PRs) --or-- fork-build-test (external fork PRs)
 
 **Purpose**: Prevents broken scheduled releases by pre-testing with latest upstream changes
 
+Builds share the same GHCR registry build cache (`<image>:buildcache`) as `pr-ci.yml` and `build.yml`, so a cache warmed by any of the three benefits the others.
+
 **Test levels**:
 
 - `basic`: Core functionality only


### PR DESCRIPTION
## Summary

Small focused follow-up to #45. That PR switched `pr-ci.yml`'s candidate build to a registry-backed buildx cache (one `<image>:buildcache` tag per image, pushed to GHCR). This PR applies the identical `--cache-from`/`--cache-to` refs to the other two places that build the same images, so all three share one warm cache instead of each keeping (or, in one case, not actually using) its own:

- **`build.yml`** (push to `main`/tags, manual, scheduled release build): had an `actions/cache` step (`/tmp/.buildx-cache`) that was never actually referenced by any `--cache-from`/`--cache-to` flag in the build steps — it was a complete no-op. Removed it and added real registry cache refs.
- **`test-scheduled-functionality.yml`** (pre-release validation build): had no caching at all. Added the same registry cache refs for the 4 images it builds (ubuntu, ubuntu-nginx, monolithic, dns).
- `TESTING.md`: noted that all three build workflows share the same cache.

Net effect: whichever of the three build workflows runs first after a cache-relevant change warms the cache for the other two — a PR build benefits from the last `main` release build, a scheduled pre-release test benefits from recent PR builds, etc.

## Not in this PR

- No change to what gets built or how images are tagged/pushed — purely a caching mechanism swap, same as #45.
- Not addressing true idempotent "skip the build entirely if upstream didn't change" — that needs upstream commit SHA resolution, which is planned as part of the Phase 3 candidate-build rework, not bolted on here.

## Test plan

- [x] `actionlint` (containerized, same pin as prior PRs), `docker compose config`, and `jq` all pass.
- [x] Confirm `build.yml`'s next run (push to `main`, or manual `workflow_dispatch`) succeeds and actually populates/reads the `buildcache` tags.
- [x] Confirm the next scheduled/manual `test-scheduled-functionality.yml` run succeeds with the added cache flags.