### PR TITLE
CI: fix cleanup-candidates pagination bug and a live-tag safety gap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,9 @@ jobs:
         with:
           name: upstream-shas-${{ github.run_id }}
           path: upstream-shas.json
-          retention-days: 90
+          # 90 was requested but this repository's max is 20; matching it
+          # directly avoids a "using 20 instead" annotation on every run.
+          retention-days: 20
 
   # Builds once, from the exact resolved SHAs above. release-promote retags
   # these same digests later; nothing is ever rebuilt after this point.
@@ -373,8 +375,24 @@ jobs:
           for image in ubuntu ubuntu-nginx monolithic generic sniproxy dns; do
             package="lancache-${image}"
             echo "Checking versions for ${package}"
-            versions=$(gh api "/users/${{ github.repository_owner }}/packages/container/${package}/versions" --paginate \
-              --jq '[.[] | select((.metadata.container.tags // []) | any(startswith("candidate-")))] | sort_by(.created_at) | reverse') || {
+            # No --paginate: it applies --jq per page rather than to the
+            # combined result (and is incompatible with --slurp), so a single
+            # large page is simpler and correct. 100 versions is far more
+            # than these packages should ever accumulate with cleanup running.
+            #
+            # A version is only eligible for deletion if it's candidate-tagged
+            # AND carries neither "latest" nor a vX.Y.Z tag. promote retags by
+            # digest rather than rebuilding, so a just-promoted candidate
+            # version and the "latest"/version tag are the same underlying
+            # version object (GHCR merges tags that point at one digest);
+            # deleting it would delete the live published tag along with it.
+            versions=$(gh api "/users/${{ github.repository_owner }}/packages/container/${package}/versions?per_page=100" \
+              --jq '[.[] | select(
+                  (.metadata.container.tags // []) as $tags
+                  | ($tags | any(startswith("candidate-")))
+                  and (($tags | any(. == "latest")) | not)
+                  and (($tags | any(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))) | not)
+                )] | sort_by(.created_at) | reverse') || {
               echo "::warning::could not list versions for ${package} (insufficient token permissions?)"
               continue
             }

--- a/TESTING.md
+++ b/TESTING.md
@@ -101,7 +101,7 @@ build-candidates (reusable, shared with pr-ci.yml)
 4. **`security-scan`**: Trivy scan of the exact candidate digests (HIGH/CRITICAL). Advisory only for now, matching the previous behavior — see the known gap below.
 5. **`release-gate`**: fails if `resolve-upstream-shas`, `build-candidates`, or `functional-test` did not succeed. A `security-scan` failure is logged as a warning but does not block.
 6. **`promote`**: only runs if `release-gate` succeeded. Retags the tested candidate digests to `latest` (and to the pushed tag name, for a `v*.*.*` push) using `docker buildx imagetools create` — a registry-side manifest copy, not a rebuild — then verifies each promoted tag resolves back to the exact digest that was tested.
-7. **`cleanup-candidates`**: best-effort deletion of old `candidate-<run-id>` package versions via the GitHub API, keeping the most recent few. Marked `continue-on-error`, since the default `GITHUB_TOKEN` may not have package-delete rights depending on repository/package settings — if deletions consistently fail, that's a repository setting to confirm, not a workflow bug.
+7. **`cleanup-candidates`**: best-effort deletion of old `candidate-<run-id>` package versions via the GitHub API, keeping the most recent few. Never deletes a version that also carries `latest` or a `vX.Y.Z` tag — `promote` retags by digest rather than rebuilding, so a just-promoted candidate version and the live release tag can be the same underlying version object (GHCR merges tags pointing at one digest). Marked `continue-on-error`, since the default `GITHUB_TOKEN` may not have package-delete rights depending on repository/package settings — if deletions consistently fail, that's a repository setting to confirm, not a workflow bug.
 
 **Blocking criteria**:
 


### PR DESCRIPTION
## Summary

Follow-up to #48. `release.yml` ran for the first time on the merge to `main` and completed successfully end-to-end (`resolve-upstream-shas` → `build-candidates` → `functional-test`/`security-scan` → `release-gate` → `promote`, all verified: every `lancache-*:latest` tag now resolves to the exact tested digest). `cleanup-candidates` is `continue-on-error`, so it didn't fail the run, but inspecting its log turned up two real bugs in that job specifically:

1. **Pagination bug**: `gh api --paginate --jq '...'` applies the `--jq` filter to *each page separately*, not to the combined result — and `--slurp` (gh's documented fix for this) is explicitly incompatible with `--jq`. The actual log showed one `"0"` printed per page plus a final `0: integer expression expected`, since the multi-line, per-page output got treated as a single value. Fixed by dropping `--paginate` and requesting `per_page=100` in one call — these packages should never realistically exceed that, especially once cleanup is actually working.
2. **Safety gap**: the eligibility filter only checked for a `candidate-*` tag. Since `promote` retags by digest rather than rebuilding, a just-promoted candidate version can carry **both** its `candidate-<run-id>` tag and `latest`/`vX.Y.Z` on the same underlying version object (GHCR merges tags that point at one digest). The old filter would have deleted that version — taking the live `latest` tag down with it — the first time cleanup actually found something to delete. Fixed by excluding any version that also carries `latest` or a `vX.Y.Z` tag, verified against a mock API payload before committing (see below).

Also matched the `upstream-shas` artifact's `retention-days` to this repo's actual 20-day cap (90 was requested and silently downgraded, with an annotation on every run).

## Verification

- Confirmed via `gh api --help` that `--slurp` is rejected together with `--jq` (the error message names it directly), ruling out that as a fix.
- Built a mock 6-entry package-versions JSON payload (including one entry with both a `candidate-*` tag and `latest`) and ran the corrected `jq` filter against it locally: the `latest`-tagged entry is correctly excluded, and the "keep the 3 most recent, mark the rest for deletion" slicing logic produces the expected 2 IDs.
- Did not exercise the real deletion path against the live registry (no reason to delete real package versions to test this).

## Test plan

- [x] `actionlint` passes.
- [x] `jq` filter logic verified against a mock payload (see above).
- [ ] Confirm the next `release.yml` run's `cleanup-candidates` job completes without the pagination error (won't have real candidates to delete yet since #48 was the first run, but the counting logic should execute cleanly).