### PR TITLE
CI: verify manifest platforms and add real ARM64 health/exit-state checks

### DIFF
--- a/.github/workflows/build-candidates.yml
+++ b/.github/workflows/build-candidates.yml
@@ -274,6 +274,40 @@ jobs:
             echo "digest=" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify published manifest platforms
+        if: inputs.push
+        env:
+          PLATFORMS: ${{ inputs.platforms }}
+        run: |
+          set -euo pipefail
+
+          IFS=',' read -ra want_raw <<< "${PLATFORMS}"
+          want=()
+          for p in "${want_raw[@]}"; do
+            # imagetools reports arm64 without the /v8 variant suffix used on
+            # the buildx --platform flag; strip it so the comparison matches.
+            want+=("${p%/v8}")
+          done
+          mapfile -t sorted_want < <(printf '%s\n' "${want[@]}" | sort)
+
+          verify() {
+            local ref="$1"
+            local got
+            mapfile -t got < <(docker buildx imagetools inspect "${ref}" --format '{{json .}}' | jq -r '.image | keys[]' | sort)
+            if [ "${sorted_want[*]}" != "${got[*]}" ]; then
+              echo "::error::${ref}: expected platforms [${sorted_want[*]}], got [${got[*]:-none}]"
+              exit 1
+            fi
+            echo "Verified ${ref} platforms: ${got[*]}"
+          }
+
+          verify "${REGISTRY}/lancache-ubuntu:${{ inputs.image_tag }}"
+          verify "${REGISTRY}/lancache-ubuntu-nginx:${{ inputs.image_tag }}"
+          verify "${REGISTRY}/lancache-monolithic:${{ inputs.image_tag }}"
+          verify "${REGISTRY}/lancache-generic:${{ inputs.image_tag }}"
+          verify "${REGISTRY}/lancache-sniproxy:${{ inputs.image_tag }}"
+          verify "${REGISTRY}/lancache-dns:${{ inputs.image_tag }}"
+
       - name: Record candidate build summary
         run: |
           {

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -96,6 +96,11 @@ jobs:
         working-directory: tests/cache-integration
         run: docker compose down -v || true
 
+  # ARM64 "core integration" per the risk-based architecture matrix in
+  # TESTING.md: not the full deterministic content-cache suite (that's
+  # AMD64-only, above), but real health/exit-state assertions plus one DNS
+  # and one HTTP assertion under actual QEMU emulation -- not just trusting
+  # `docker compose ps` to notice a crash.
   functional-arm64:
     needs: build-candidates
     if: success() && github.event.pull_request.head.repo.full_name == github.repository
@@ -103,6 +108,9 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    env:
+      DNS_IMAGE: ghcr.io/${{ github.repository_owner }}/lancache-dns@${{ needs.build-candidates.outputs.dns_digest }}
+      MONOLITHIC_IMAGE: ghcr.io/${{ github.repository_owner }}/lancache-monolithic@${{ needs.build-candidates.outputs.monolithic_digest }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -113,23 +121,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Test ARM64 image compatibility
-        env:
-          DNS_IMAGE: ${{ env.REGISTRY }}/lancache-dns@${{ needs.build-candidates.outputs.dns_digest }}
-          MONOLITHIC_IMAGE: ${{ env.REGISTRY }}/lancache-monolithic@${{ needs.build-candidates.outputs.monolithic_digest }}
+      - name: Start ARM64 containers
         run: |
-          echo "Testing ARM64 images can be pulled and started..."
-
+          set -euo pipefail
           mkdir -p test-cache/cache test-cache/logs
           chmod 777 test-cache/cache test-cache/logs
 
-          cat > test.env << EOF
-          LANCACHE_IP=10.0.0.100
-          CACHE_ROOT=$PWD/test-cache
-          CACHE_MAX_AGE=3650d
+          cat > test.env << 'EOF'
+          LANCACHE_IP=10.55.0.11
           USE_GENERIC_CACHE=true
           UPSTREAM_DNS=8.8.8.8
           ENABLE_DNSSEC_VALIDATION=false
+          CACHE_MAX_AGE=3650d
           EOF
 
           cat > test-compose-arm64.yml << EOF
@@ -138,46 +141,104 @@ jobs:
               image: ${DNS_IMAGE}
               platform: linux/arm64
               env_file: test.env
-              ports:
-                - "127.0.0.1:5353:53/udp"
               networks:
                 lancache_test:
-                  ipv4_address: 10.0.0.100
+                  ipv4_address: 10.55.0.10
+              healthcheck:
+                test: ["CMD", "nslookup", "lancache.steamcontent.com", "127.0.0.1"]
+                interval: 10s
+                timeout: 10s
+                retries: 15
+                start_period: 30s
 
             monolithic:
               image: ${MONOLITHIC_IMAGE}
               platform: linux/arm64
               env_file: test.env
-              ports:
-                - "127.0.0.1:8080:80/tcp"
               volumes:
                 - ./test-cache/cache:/data/cache
                 - ./test-cache/logs:/data/logs
               networks:
                 lancache_test:
-                  ipv4_address: 10.0.0.101
+                  ipv4_address: 10.55.0.11
+              healthcheck:
+                test: ["CMD", "curl", "-fsS", "http://127.0.0.1/lancache-heartbeat"]
+                interval: 10s
+                timeout: 10s
+                retries: 15
+                start_period: 45s
 
           networks:
             lancache_test:
               driver: bridge
               ipam:
                 config:
-                  - subnet: 10.0.0.0/24
+                  - subnet: 10.55.0.0/24
           EOF
 
-          echo "Testing ARM64 image pull..."
-          docker compose -f test-compose-arm64.yml pull
+          docker compose -f test-compose-arm64.yml up -d
 
-          echo "Testing ARM64 containers start..."
-          timeout 180 docker compose -f test-compose-arm64.yml up -d
+      - name: Wait for containers to be healthy
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            dns_status=$(docker inspect --format '{{.State.Health.Status}}' "$(docker compose -f test-compose-arm64.yml ps -q dns)")
+            mono_status=$(docker inspect --format '{{.State.Health.Status}}' "$(docker compose -f test-compose-arm64.yml ps -q monolithic)")
+            echo "dns=${dns_status} monolithic=${mono_status}"
+            if [ "${dns_status}" = "healthy" ] && [ "${mono_status}" = "healthy" ]; then
+              exit 0
+            fi
+            if [ "${dns_status}" = "unhealthy" ] || [ "${mono_status}" = "unhealthy" ]; then
+              echo "::error::a container reported unhealthy"
+              exit 1
+            fi
+            sleep 10
+          done
+          echo "::error::containers did not become healthy in time"
+          exit 1
 
-          sleep 30
+      - name: Assert neither container has exited
+        run: |
+          set -euo pipefail
+          for svc in dns monolithic; do
+            cid=$(docker compose -f test-compose-arm64.yml ps -q "${svc}")
+            status=$(docker inspect --format '{{.State.Status}}' "${cid}")
+            if [ "${status}" != "running" ]; then
+              echo "::error::${svc} container is not running (status: ${status})"
+              exit 1
+            fi
+          done
+          echo "Both containers running"
 
-          echo "Checking ARM64 container status..."
+      - name: DNS assertion under ARM64 emulation
+        run: |
+          set -euo pipefail
+          result=$(docker compose -f test-compose-arm64.yml exec -T dns nslookup lancache.steamcontent.com 127.0.0.1 2>/dev/null | grep "^Address:" | tail -1 | awk '{print $2}' | tr -d '\r')
+          if [ "${result}" != "10.55.0.11" ]; then
+            echo "::error::expected lancache.steamcontent.com to resolve to 10.55.0.11 under ARM64, got '${result}'"
+            exit 1
+          fi
+          echo "DNS resolution OK under ARM64 emulation"
+
+      - name: HTTP assertion under ARM64 emulation
+        run: |
+          set -euo pipefail
+          status=$(docker compose -f test-compose-arm64.yml exec -T monolithic curl -s -o /dev/null -w '%{http_code}' -H 'Host: lancache.steamcontent.com' http://127.0.0.1/lancache-heartbeat)
+          if [ "${status}" != "200" ] && [ "${status}" != "204" ]; then
+            echo "::error::expected 200/204 from heartbeat under ARM64, got ${status}"
+            exit 1
+          fi
+          echo "HTTP heartbeat OK under ARM64 emulation (status ${status})"
+
+      - name: Collect diagnostics
+        if: failure()
+        run: |
           docker compose -f test-compose-arm64.yml ps
+          docker compose -f test-compose-arm64.yml logs
 
-          echo "✅ ARM64 images are compatible"
-
+      - name: Cleanup
+        if: always()
+        run: |
           docker compose -f test-compose-arm64.yml down -v || true
           rm -rf test-cache test.env test-compose-arm64.yml || true
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -68,9 +68,24 @@ The origin (`tests/cache-integration/origin/`) is a small Python HTTP server ser
 **Architecture testing**:
 
 - **AMD64**: Full deterministic cache integration test described above.
-- **ARM64**: Compatibility tests with core functionality (via QEMU emulation) — still heartbeat/startup-level only; deeper ARM64 assertions are tracked for a later architecture-coverage PR.
+- **ARM64**: Real health/exit-state assertions (not just trusting `docker compose ps`) plus one DNS and one HTTP assertion against the actual candidate images, under QEMU emulation. A container that exits immediately, or never reaches `healthy`, fails the job.
 
 > **Known gap (tracked for a follow-up PR)**: cache revalidation (`proxy_cache_revalidate`) and stale-response-on-upstream-error (`proxy_cache_use_stale`) are not yet covered. Both need a short-TTL cache configuration to force staleness within test time, which is a distinct environment from the single shared stack used above (see Phase 2.4's "simplify the matrix" guidance) — planned as a small dedicated addition rather than bundled here.
+
+### Architecture and component coverage matrix
+
+Every image is built for AMD64, ARM64, and ARMv7 (`build-candidates.yml`), which also verifies the published manifest actually contains all three platforms before returning digests — a build that silently drops a platform fails before it can reach a test, let alone promotion. Runtime coverage below is intentionally risk-proportionate: heavier for the images most central to correct caching, lighter for images that are mostly pass-through:
+
+| Image | AMD64 | ARM64 | ARMv7 | Required behavior | Status |
+| --- | --- | --- | --- | --- | --- |
+| `lancache-ubuntu` | Build/smoke | Build/smoke | Build/smoke | Starts and runs a basic command | Manifest-verified; no dedicated runtime smoke test yet |
+| `lancache-ubuntu-nginx` | Build/smoke | Build/smoke | Build/smoke | Nginx starts and config validates | Manifest-verified; no dedicated runtime smoke test yet |
+| `lancache-monolithic` | Full integration | Core integration | Startup/heartbeat | DNS-to-cache and content behavior | AMD64 full + ARM64 core done; ARMv7 pending |
+| `lancache-generic` | Startup/function | Startup/function | Startup | Derived image uses the intended candidate base | Pending |
+| `lancache-sniproxy` | Startup/TLS path | Startup/TLS path | Startup | TLS pass-through reaches a controlled origin | Pending |
+| `lancache-dns` | Full DNS | Core DNS | Startup/query | Cacheable and forwarded lookups work | AMD64 full + ARM64 core done; ARMv7 pending |
+
+> **Known gap (tracked for follow-up PRs)**: `generic` and `sniproxy` have no dedicated runtime test at all today (only a manifest-platform check), and no image has ARMv7 runtime coverage yet — ARMv7 QEMU emulation is slow enough that it's planned for the release-gate's deeper suite rather than every PR, per the plan's "fast required suite, deeper scheduled suite" principle. The repository's own `docker-compose.yml` is not yet tested against candidate images either.
 
 ### 3. Release (`.github/workflows/release.yml`)
 


### PR DESCRIPTION
## Summary

First slice of Phase 4 (architecture and component coverage) — this is a smaller, focused PR rather than all of Phase 4 at once. Adds a documented risk-based coverage matrix to `TESTING.md` and closes two of its acceptance criteria directly:

- Missing manifest platforms must fail before promotion.
- A container that exits immediately cannot pass an architecture smoke test.

### Manifest platform verification (`build-candidates.yml`)

After all six images are built and pushed, a new step inspects each one's published manifest (`docker buildx imagetools inspect ... | jq '.image | keys'`) and fails if the platform set doesn't match what was requested, rather than trusting that a `--platform` flag produced what it asked for. This runs in the shared reusable workflow, so it applies to both `pr-ci.yml` and `release.yml` builds automatically.

### Real ARM64 health/exit-state checks (`pr-ci.yml`)

`functional-arm64` previously did `docker compose up -d`, slept 30 seconds, ran `docker compose ps`, and then **unconditionally** printed "✅ ARM64 images are compatible" regardless of what `ps` actually showed. It now:

- Waits on each container's actual Docker healthcheck status, failing if either reports `unhealthy` or times out instead of just sleeping a fixed amount.
- Explicitly asserts both containers are still `running` (not exited).
- Runs one real DNS assertion (a cache-domain hostname resolves to monolithic's IP) and one real HTTP assertion (heartbeat responds through monolithic with the right Host header) — both under actual QEMU emulation, not just a pull-and-start check.

This matches "core integration" for `monolithic` and "core DNS" for `dns` in the new coverage matrix (full deterministic testing is AMD64-only, per Phase 2.4 — see `tests/cache-integration/`).

### Documented coverage matrix (`TESTING.md`)

Added the full 6-image × 3-platform risk-based matrix from the plan, with a status column showing what's actually implemented today vs. pending. Flagged as known gaps: `generic` and `sniproxy` have no dedicated runtime test yet (manifest-check only), no image has ARMv7 runtime coverage yet, and the repository's own `docker-compose.yml` isn't tested against candidates — all tracked as follow-up PRs rather than bundled here.

## A bug this caught before it ever reached CI

While testing the rewritten ARM64 job locally (native ARM64 on my machine, identical compose config to what CI runs), the new health/exit-state check immediately caught a real bug **in the new job itself**: the DNS container's env was missing `USE_GENERIC_CACHE=true`, so it exited immediately on startup. The *old* job's bare `docker compose ps` + unconditional success message would have silently passed straight through that. Fixed before pushing.

## Not in this PR

- `generic`/`sniproxy` dedicated smoke tests, sniproxy TLS/port-443 test, ARMv7 runtime coverage, and the repository `docker-compose.yml` test — remaining Phase 4 items, planned as follow-up PRs.

## Test plan

- [x] `actionlint` passes.
- [x] Verified the platform-verification logic locally against a real published multi-arch image: passes when the manifest matches, fails when an additional (nonexistent) platform is requested.
- [x] Verified the full rewritten ARM64 job locally end-to-end (wait-for-healthy loop, exit-state assertion, DNS assertion, HTTP assertion) against the real published images, including catching and fixing the `USE_GENERIC_CACHE` bug described above.
- [x] Confirm `functional-arm64` and the manifest-verification step both pass on this PR in real CI.