### PR TITLE
CI: add dedicated component test for lancache-generic

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -242,6 +242,102 @@ jobs:
           docker compose -f test-compose-arm64.yml down -v || true
           rm -rf test-cache test.env test-compose-arm64.yml || true
 
+  # "Startup/function" row of the architecture matrix in TESTING.md for
+  # lancache-generic, which has had no dedicated runtime test until now.
+  component-generic:
+    needs: build-candidates
+    if: success() && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      GENERIC_IMAGE: ghcr.io/${{ github.repository_owner }}/lancache-generic@${{ needs.build-candidates.outputs.generic_digest }}
+      MONOLITHIC_IMAGE: ghcr.io/${{ github.repository_owner }}/lancache-monolithic@${{ needs.build-candidates.outputs.monolithic_digest }}
+
+    steps:
+      - name: Verify generic is derived from the candidate monolithic base
+        run: |
+          set -euo pipefail
+          docker pull "${GENERIC_IMAGE}" >/dev/null
+          docker pull "${MONOLITHIC_IMAGE}" >/dev/null
+          docker inspect "${MONOLITHIC_IMAGE}" --format '{{json .RootFS.Layers}}' > /tmp/mono_layers.json
+          docker inspect "${GENERIC_IMAGE}" --format '{{json .RootFS.Layers}}' > /tmp/generic_layers.json
+          python3 -c "
+          import json
+          with open('/tmp/mono_layers.json') as f:
+              mono = json.load(f)
+          with open('/tmp/generic_layers.json') as f:
+              gen = json.load(f)
+          if gen[: len(mono)] != mono:
+              raise SystemExit(
+                  'lancache-generic layers are not a superset of lancache-monolithic '
+                  'layers; its base may not be the tested candidate build'
+              )
+          print(f'Verified: generic inherits all {len(mono)} monolithic layers, plus {len(gen) - len(mono)} of its own')
+          "
+
+      - name: Start generic container
+        run: |
+          set -euo pipefail
+          mkdir -p test-cache/cache test-cache/logs
+          chmod 777 test-cache/cache test-cache/logs
+          cat > test.env << 'EOF'
+          LANCACHE_IP=10.66.0.10
+          USE_GENERIC_CACHE=true
+          UPSTREAM_DNS=8.8.8.8
+          CACHE_MAX_AGE=3650d
+          EOF
+          docker run -d --name generic-test \
+            --env-file test.env \
+            -v "$PWD/test-cache/cache:/data/cache" \
+            -v "$PWD/test-cache/logs:/data/logs" \
+            -p 18080:80 \
+            --health-cmd="curl -fsS http://127.0.0.1/lancache-heartbeat" \
+            --health-interval=10s --health-timeout=10s --health-retries=15 --health-start-period=45s \
+            "${GENERIC_IMAGE}"
+
+      - name: Wait for healthy
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            st=$(docker inspect --format '{{.State.Health.Status}}' generic-test)
+            echo "status=${st}"
+            if [ "${st}" = "healthy" ]; then exit 0; fi
+            if [ "${st}" = "unhealthy" ]; then
+              echo "::error::generic reported unhealthy"
+              exit 1
+            fi
+            sleep 10
+          done
+          echo "::error::generic did not become healthy in time"
+          exit 1
+
+      - name: Assert running and functional
+        run: |
+          set -euo pipefail
+          st=$(docker inspect --format '{{.State.Status}}' generic-test)
+          if [ "${st}" != "running" ]; then
+            echo "::error::generic container is not running (status: ${st})"
+            exit 1
+          fi
+          code=$(curl -s -o /dev/null -w '%{http_code}' -H 'Host: lancache.steamcontent.com' http://127.0.0.1:18080/lancache-heartbeat)
+          if [ "${code}" != "200" ] && [ "${code}" != "204" ]; then
+            echo "::error::expected 200/204 from generic heartbeat, got ${code}"
+            exit 1
+          fi
+          echo "generic is running and functional (HTTP ${code})"
+
+      - name: Collect diagnostics
+        if: failure()
+        run: docker logs generic-test || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f generic-test || true
+          rm -rf test-cache test.env || true
+
   # Exercises actions/upload-artifact and actions/download-artifact directly so a
   # Renovate PR bumping either action runs the exact dependency it changes.
   artifact-contracts:
@@ -412,6 +508,7 @@ jobs:
       - build-candidates
       - functional-amd64
       - functional-arm64
+      - component-generic
       - artifact-contracts
       - fork-build-test
     if: always()
@@ -427,11 +524,12 @@ jobs:
           BUILD_RESULT: ${{ needs.build-candidates.result }}
           AMD64_RESULT: ${{ needs.functional-amd64.result }}
           ARM64_RESULT: ${{ needs.functional-arm64.result }}
+          GENERIC_RESULT: ${{ needs.component-generic.result }}
           ARTIFACT_RESULT: ${{ needs.artifact-contracts.result }}
           FORK_RESULT: ${{ needs.fork-build-test.result }}
         run: |
           set -euo pipefail
-          echo "is_fork=$IS_FORK validate=$VALIDATE_RESULT build=$BUILD_RESULT amd64=$AMD64_RESULT arm64=$ARM64_RESULT artifact=$ARTIFACT_RESULT fork=$FORK_RESULT"
+          echo "is_fork=$IS_FORK validate=$VALIDATE_RESULT build=$BUILD_RESULT amd64=$AMD64_RESULT arm64=$ARM64_RESULT generic=$GENERIC_RESULT artifact=$ARTIFACT_RESULT fork=$FORK_RESULT"
 
           if [ "$VALIDATE_RESULT" != "success" ]; then
             echo "::error::validate did not succeed ($VALIDATE_RESULT)"
@@ -445,7 +543,7 @@ jobs:
             fi
           else
             failed=0
-            for pair in "build-candidates:$BUILD_RESULT" "functional-amd64:$AMD64_RESULT" "functional-arm64:$ARM64_RESULT" "artifact-contracts:$ARTIFACT_RESULT"; do
+            for pair in "build-candidates:$BUILD_RESULT" "functional-amd64:$AMD64_RESULT" "functional-arm64:$ARM64_RESULT" "component-generic:$GENERIC_RESULT" "artifact-contracts:$ARTIFACT_RESULT"; do
               name="${pair%%:*}"
               result="${pair##*:}"
               if [ "$result" != "success" ]; then

--- a/TESTING.md
+++ b/TESTING.md
@@ -41,6 +41,7 @@ build-candidates (same-repo PRs) --or-- fork-build-test (external fork PRs)
    |
    +--> functional-amd64
    +--> functional-arm64
+   +--> component-generic
    +--> artifact-contracts
               |
            ci-gate
@@ -81,11 +82,13 @@ Every image is built for AMD64, ARM64, and ARMv7 (`build-candidates.yml`), which
 | `lancache-ubuntu` | Build/smoke | Build/smoke | Build/smoke | Starts and runs a basic command | Manifest-verified; no dedicated runtime smoke test yet |
 | `lancache-ubuntu-nginx` | Build/smoke | Build/smoke | Build/smoke | Nginx starts and config validates | Manifest-verified; no dedicated runtime smoke test yet |
 | `lancache-monolithic` | Full integration | Core integration | Startup/heartbeat | DNS-to-cache and content behavior | AMD64 full + ARM64 core done; ARMv7 pending |
-| `lancache-generic` | Startup/function | Startup/function | Startup | Derived image uses the intended candidate base | Pending |
+| `lancache-generic` | Startup/function | Startup/function | Startup | Derived image uses the intended candidate base | AMD64 done (`component-generic`); ARM64/ARMv7 pending |
 | `lancache-sniproxy` | Startup/TLS path | Startup/TLS path | Startup | TLS pass-through reaches a controlled origin | Pending |
 | `lancache-dns` | Full DNS | Core DNS | Startup/query | Cacheable and forwarded lookups work | AMD64 full + ARM64 core done; ARMv7 pending |
 
-> **Known gap (tracked for follow-up PRs)**: `generic` and `sniproxy` have no dedicated runtime test at all today (only a manifest-platform check), and no image has ARMv7 runtime coverage yet — ARMv7 QEMU emulation is slow enough that it's planned for the release-gate's deeper suite rather than every PR, per the plan's "fast required suite, deeper scheduled suite" principle. The repository's own `docker-compose.yml` is not yet tested against candidate images either.
+`component-generic` verifies "derived image uses the intended candidate base" directly: it compares `lancache-generic`'s and `lancache-monolithic`'s `RootFS.Layers` and asserts monolithic's full layer list is an exact prefix of generic's — since layers are content-addressed, this proves generic's `FROM` really resolved to the tested candidate monolithic digest (not a stale or wrong base) without needing any custom build-time markers.
+
+> **Known gap (tracked for follow-up PRs)**: `sniproxy` has no dedicated runtime test at all today (only a manifest-platform check), and no image has ARMv7 or ARM64 (for `generic`) runtime coverage yet — ARMv7 QEMU emulation is slow enough that it's planned for the release-gate's deeper suite rather than every PR, per the plan's "fast required suite, deeper scheduled suite" principle. The repository's own `docker-compose.yml` is not yet tested against candidate images either.
 
 ### 3. Release (`.github/workflows/release.yml`)
 


### PR DESCRIPTION
## Summary

Second slice of Phase 4 (follows #50). `lancache-generic` previously had zero dedicated runtime testing — it only got whatever incidental coverage came from being built and manifest-verified. Adds `component-generic` to `pr-ci.yml` (and to `ci-gate`'s required set), covering the "Startup/function" row of the architecture matrix in `TESTING.md`, plus its specific required behavior: "Derived image uses the intended candidate base".

### Base-lineage verification

Compares `lancache-generic`'s and `lancache-monolithic`'s `RootFS.Layers` (`docker inspect ... --format '{{json .RootFS.Layers}}'`) and asserts monolithic's full layer list is an exact prefix of generic's. Since Docker layers are content-addressed, this directly proves generic's `FROM` really resolved to the tested candidate monolithic digest — not a stale or wrong base — without needing any custom build-time markers baked into the images. Verified locally against the real published images: monolithic's 12 layers are an exact prefix of generic's 15.

### Startup/functional smoke test

Starts the candidate image with a real Docker healthcheck, waits on its actual health status (failing on `unhealthy` or timeout — not a fixed `sleep 30`), explicitly asserts the container is still `running`, and checks the heartbeat endpoint responds correctly. Verified locally end-to-end against the real published image.

## Verified locally before wiring in

- The layer-prefix comparison logic, against the real published `lancache-generic`/`lancache-monolithic` images.
- The full startup → healthcheck-wait → running-assertion → HTTP-assertion sequence, against the real published `lancache-generic` image.
- The embedded Python snippet's indentation survives GitHub's YAML block-scalar processing correctly — extracted the actual step content via PyYAML (matching what GitHub Actions itself would parse) and ran it directly, rather than assuming.

## Not in this PR

- `sniproxy`'s TLS pass-through test — needs a small TLS-terminating origin fixture and SNI-override client testing, different enough in shape to warrant its own PR.
- ARM64/ARMv7 coverage for `generic` — AMD64 "Startup/function" only, per the matrix.
- The repository `docker-compose.yml` test.

## Test plan

- [x] `actionlint`, `docker compose config`, `jq` all pass.
- [x] Both the lineage check and the startup/functional smoke test verified locally against the real published images.
- [ ] Confirm `component-generic` passes in real CI on this PR.