### PR TITLE
CI: add sniproxy TLS SNI pass-through component test

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -338,6 +338,41 @@ jobs:
           docker rm -f generic-test || true
           rm -rf test-cache test.env || true
 
+  # "Startup/TLS path" row of the architecture matrix in TESTING.md for
+  # lancache-sniproxy, which has had no dedicated runtime test until now.
+  component-sniproxy:
+    needs: build-candidates
+    if: success() && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      SNIPROXY_IMAGE: ghcr.io/${{ github.repository_owner }}/lancache-sniproxy@${{ needs.build-candidates.outputs.sniproxy_digest }}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Start sniproxy TLS fixture
+        working-directory: tests/sniproxy
+        run: docker compose up -d --build
+
+      - name: Run sniproxy TLS pass-through test
+        working-directory: tests/sniproxy
+        run: bash run-sniproxy-test.sh
+
+      - name: Collect diagnostics
+        if: failure()
+        working-directory: tests/sniproxy
+        run: |
+          docker compose ps
+          docker compose logs
+
+      - name: Cleanup
+        if: always()
+        working-directory: tests/sniproxy
+        run: docker compose down -v || true
+
   # Exercises actions/upload-artifact and actions/download-artifact directly so a
   # Renovate PR bumping either action runs the exact dependency it changes.
   artifact-contracts:
@@ -509,6 +544,7 @@ jobs:
       - functional-amd64
       - functional-arm64
       - component-generic
+      - component-sniproxy
       - artifact-contracts
       - fork-build-test
     if: always()
@@ -525,11 +561,12 @@ jobs:
           AMD64_RESULT: ${{ needs.functional-amd64.result }}
           ARM64_RESULT: ${{ needs.functional-arm64.result }}
           GENERIC_RESULT: ${{ needs.component-generic.result }}
+          SNIPROXY_RESULT: ${{ needs.component-sniproxy.result }}
           ARTIFACT_RESULT: ${{ needs.artifact-contracts.result }}
           FORK_RESULT: ${{ needs.fork-build-test.result }}
         run: |
           set -euo pipefail
-          echo "is_fork=$IS_FORK validate=$VALIDATE_RESULT build=$BUILD_RESULT amd64=$AMD64_RESULT arm64=$ARM64_RESULT generic=$GENERIC_RESULT artifact=$ARTIFACT_RESULT fork=$FORK_RESULT"
+          echo "is_fork=$IS_FORK validate=$VALIDATE_RESULT build=$BUILD_RESULT amd64=$AMD64_RESULT arm64=$ARM64_RESULT generic=$GENERIC_RESULT sniproxy=$SNIPROXY_RESULT artifact=$ARTIFACT_RESULT fork=$FORK_RESULT"
 
           if [ "$VALIDATE_RESULT" != "success" ]; then
             echo "::error::validate did not succeed ($VALIDATE_RESULT)"
@@ -543,7 +580,7 @@ jobs:
             fi
           else
             failed=0
-            for pair in "build-candidates:$BUILD_RESULT" "functional-amd64:$AMD64_RESULT" "functional-arm64:$ARM64_RESULT" "component-generic:$GENERIC_RESULT" "artifact-contracts:$ARTIFACT_RESULT"; do
+            for pair in "build-candidates:$BUILD_RESULT" "functional-amd64:$AMD64_RESULT" "functional-arm64:$ARM64_RESULT" "component-generic:$GENERIC_RESULT" "component-sniproxy:$SNIPROXY_RESULT" "artifact-contracts:$ARTIFACT_RESULT"; do
               name="${pair%%:*}"
               result="${pair##*:}"
               if [ "$result" != "success" ]; then

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,6 +48,11 @@ jobs:
           DNS_IMAGE=placeholder MONOLITHIC_IMAGE=placeholder \
             docker compose -f tests/cache-integration/docker-compose.yml config -q
 
+      - name: Validate sniproxy test Compose file
+        run: |
+          SNIPROXY_IMAGE=placeholder \
+            docker compose -f tests/sniproxy/docker-compose.yml config -q
+
       - name: ShellCheck extracted test scripts
         run: |
           mapfile -d '' -t scripts < <(find tests scripts -type f -name '*.sh' -print0)

--- a/TESTING.md
+++ b/TESTING.md
@@ -42,6 +42,7 @@ build-candidates (same-repo PRs) --or-- fork-build-test (external fork PRs)
    +--> functional-amd64
    +--> functional-arm64
    +--> component-generic
+   +--> component-sniproxy
    +--> artifact-contracts
               |
            ci-gate
@@ -49,7 +50,7 @@ build-candidates (same-repo PRs) --or-- fork-build-test (external fork PRs)
 
 `ci-gate` is the single stable, non-matrix check intended to be required in branch protection. It explicitly evaluates the result of every job above (including the same-repo/fork branch that actually ran) and fails if any required job failed, was cancelled, or was skipped when it should have run.
 
-**Same-repository PRs** (including Renovate): `build-candidates` builds all six images once per revision, pushes them to GHCR tagged `pr-<number>-<head-sha>` (immutable — a new commit gets a new tag rather than overwriting the previous revision's images), and captures each image's manifest digest as a job output. `functional-amd64`, `functional-arm64`, and `artifact-contracts` all consume those exact digests, so updating a PR cannot cause a test to run against a stale image.
+**Same-repository PRs** (including Renovate): `build-candidates` builds all six images once per revision, pushes them to GHCR tagged `pr-<number>-<head-sha>` (immutable — a new commit gets a new tag rather than overwriting the previous revision's images), and captures each image's manifest digest as a job output. `functional-amd64`, `functional-arm64`, `component-generic`, `component-sniproxy`, and `artifact-contracts` all consume those exact digests, so updating a PR cannot cause a test to run against a stale image.
 
 **External fork PRs**: GitHub always issues a read-only `GITHUB_TOKEN` for `pull_request` runs from forks, regardless of the `permissions:` declared in the workflow, so `build-candidates` cannot push to GHCR for fork PRs. `fork-build-test` runs instead: a local, AMD64-only build (`--load`, no `--push`, no registry login) with a basic heartbeat smoke test. Fork PRs do not get ARM64 or artifact-contract coverage.
 
@@ -83,10 +84,12 @@ Every image is built for AMD64, ARM64, and ARMv7 (`build-candidates.yml`), which
 | `lancache-ubuntu-nginx` | Build/smoke | Build/smoke | Build/smoke | Nginx starts and config validates | Manifest-verified; no dedicated runtime smoke test yet |
 | `lancache-monolithic` | Full integration | Core integration | Startup/heartbeat | DNS-to-cache and content behavior | AMD64 full + ARM64 core done; ARMv7 pending |
 | `lancache-generic` | Startup/function | Startup/function | Startup | Derived image uses the intended candidate base | AMD64 done (`component-generic`); ARM64/ARMv7 pending |
-| `lancache-sniproxy` | Startup/TLS path | Startup/TLS path | Startup | TLS pass-through reaches a controlled origin | Pending |
+| `lancache-sniproxy` | Startup/TLS path | Startup/TLS path | Startup | TLS pass-through reaches a controlled origin | AMD64 done (`component-sniproxy`); ARM64/ARMv7 pending |
 | `lancache-dns` | Full DNS | Core DNS | Startup/query | Cacheable and forwarded lookups work | AMD64 full + ARM64 core done; ARMv7 pending |
 
 `component-generic` verifies "derived image uses the intended candidate base" directly: it compares `lancache-generic`'s and `lancache-monolithic`'s `RootFS.Layers` and asserts monolithic's full layer list is an exact prefix of generic's — since layers are content-addressed, this proves generic's `FROM` really resolved to the tested candidate monolithic digest (not a stale or wrong base) without needing any custom build-time markers.
+
+`component-sniproxy` (`tests/sniproxy/`) verifies "TLS pass-through reaches a controlled origin": a small self-signed-TLS nginx origin is registered under a network alias (`sniproxy-test.internal`); a client container first confirms the origin serves known content directly (sanity check that the fixture itself is correct), then uses `curl --connect-to sniproxy-test.internal:443:sniproxy:443` to force the same request's *TCP connection* through the candidate sniproxy container while keeping the *SNI hostname* unchanged. sniproxy resolves that hostname via Docker's embedded DNS (`UPSTREAM_DNS=127.0.0.11`) and passes the TLS bytes straight through to the origin without terminating TLS itself. The response must match the origin's known content exactly, proving the pass-through actually reached the intended destination rather than erroring, hanging, or connecting elsewhere.
 
 > **Known gap (tracked for follow-up PRs)**: `sniproxy` has no dedicated runtime test at all today (only a manifest-platform check), and no image has ARMv7 or ARM64 (for `generic`) runtime coverage yet — ARMv7 QEMU emulation is slow enough that it's planned for the release-gate's deeper suite rather than every PR, per the plan's "fast required suite, deeper scheduled suite" principle. The repository's own `docker-compose.yml` is not yet tested against candidate images either.
 

--- a/tests/sniproxy/docker-compose.yml
+++ b/tests/sniproxy/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  origin:
+    build:
+      context: origin
+    networks:
+      sniproxy_test:
+        aliases:
+          - sniproxy-test.internal
+    healthcheck:
+      test: ["CMD", "curl", "-ks", "-o", "/dev/null", "https://127.0.0.1/"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  sniproxy:
+    image: ${SNIPROXY_IMAGE:?SNIPROXY_IMAGE must be set}
+    environment:
+      # Docker's embedded resolver, so sniproxy resolves the origin's network
+      # alias the same way any other container on this network would.
+      UPSTREAM_DNS: "127.0.0.11"
+    networks:
+      - sniproxy_test
+
+  client:
+    build:
+      context: ../cache-integration/client
+    networks:
+      - sniproxy_test
+    depends_on:
+      origin:
+        condition: service_healthy
+
+networks:
+  sniproxy_test:
+    driver: bridge

--- a/tests/sniproxy/origin/Dockerfile
+++ b/tests/sniproxy/origin/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
+
+RUN apk add --no-cache openssl curl \
+    && openssl req -x509 -nodes -newkey rsa:2048 \
+         -keyout /etc/nginx/tls.key -out /etc/nginx/tls.crt \
+         -days 3650 -subj "/CN=sniproxy-test.internal"
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY html /usr/share/nginx/html
+
+EXPOSE 443

--- a/tests/sniproxy/origin/html/index.html
+++ b/tests/sniproxy/origin/html/index.html
@@ -1,0 +1,1 @@
+sniproxy-tls-passthrough-ok

--- a/tests/sniproxy/origin/nginx.conf
+++ b/tests/sniproxy/origin/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 443 ssl;
+    server_name sniproxy-test.internal;
+
+    ssl_certificate /etc/nginx/tls.crt;
+    ssl_certificate_key /etc/nginx/tls.key;
+
+    location / {
+        root /usr/share/nginx/html;
+    }
+}

--- a/tests/sniproxy/run-sniproxy-test.sh
+++ b/tests/sniproxy/run-sniproxy-test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# TLS SNI pass-through test: proves the candidate sniproxy image correctly
+# forwards a TLS connection to a controlled origin based on SNI, without
+# terminating TLS itself. Run from this directory with SNIPROXY_IMAGE
+# already exported and `docker compose up -d --build` already applied.
+set -euo pipefail
+
+EXPECTED_CONTENT="sniproxy-tls-passthrough-ok"
+
+echo "== Sanity check: origin serves the expected content directly =="
+# "sniproxy-test.internal" is registered as a network alias for the origin
+# service itself, so a plain request (no --connect-to override) resolves
+# straight to origin, bypassing sniproxy entirely -- confirming the fixture
+# itself is correct before trusting the pass-through result below.
+direct=$(docker compose exec -T client curl -sk "https://sniproxy-test.internal/")
+if [ "${direct}" != "${EXPECTED_CONTENT}" ]; then
+  echo "FAIL: origin fixture itself did not return the expected content (got '${direct}')" >&2
+  exit 1
+fi
+echo "OK: origin fixture serves '${EXPECTED_CONTENT}' directly"
+
+echo "== TLS SNI pass-through through candidate sniproxy =="
+via_sniproxy=$(docker compose exec -T client curl -sk \
+  --connect-to sniproxy-test.internal:443:sniproxy:443 \
+  https://sniproxy-test.internal/)
+
+if [ "${via_sniproxy}" != "${EXPECTED_CONTENT}" ]; then
+  echo "FAIL: expected '${EXPECTED_CONTENT}' through sniproxy, got '${via_sniproxy}'" >&2
+  exit 1
+fi
+
+echo "OK: TLS SNI pass-through through sniproxy reached the controlled origin"


### PR DESCRIPTION
## Summary

Third slice of Phase 4 (follows #50, #51). `lancache-sniproxy` previously had zero dedicated runtime testing — just a manifest-platform check. Adds `component-sniproxy` to `pr-ci.yml` (and to `ci-gate`'s required set), covering the "Startup/TLS path" row of the architecture matrix and its specific required behavior: "TLS pass-through reaches a controlled origin".

### How the test works

`tests/sniproxy/` is a committed fixture:

- `origin/`: a small nginx image with a self-signed TLS cert, serving one known string over HTTPS. Registered under a Compose network alias (`sniproxy-test.internal`) so any container on the test network resolves it via normal DNS.
- The test first confirms the **origin fixture itself** serves the known content directly (a plain request to `sniproxy-test.internal` resolves straight to origin via the alias, bypassing sniproxy — this is a sanity check on the fixture, not the thing under test).
- It then uses `curl --connect-to sniproxy-test.internal:443:sniproxy:443` to force that **same request's TCP connection** through the candidate `sniproxy` container while keeping the **SNI hostname unchanged**. sniproxy resolves `sniproxy-test.internal` via Docker's embedded DNS (`UPSTREAM_DNS=127.0.0.11` — the same resolver any container on the network uses) and passes the TLS bytes straight through to origin, without terminating TLS itself (sniproxy has no certs of its own; it's a pure SNI-based L4 proxy — confirmed by reading its actual `/etc/sniproxy.conf`: `listener 0.0.0.0:443 { protocol tls }` / `table { .* *:443 }`).
- Asserts the response through sniproxy matches the origin's known content exactly — proving the pass-through actually reached the intended destination rather than erroring, hanging, or silently connecting somewhere else.

## Verified locally before wiring in

- The whole fixture end-to-end against the real published `lancache-sniproxy` image: both the direct-to-origin sanity check and the pass-through-via-sniproxy request return the expected content.
- Cross-checked sniproxy's own access log, which independently confirms the proxied connection: it records the exact SNI hostname and tx/rx byte counts for the request, not just "it returned 200."
- A fault-injection sanity check (temporarily changing the expected content string) confirming the test harness actually fails with a clear message rather than passing vacuously.
- `actionlint`, `shellcheck` on the new script, and `docker compose config` on the new fixture (and the existing ones) all pass.

## Not in this PR

- ARM64/ARMv7 coverage for `sniproxy` — AMD64 "Startup/TLS path" only, per the matrix.
- The repository `docker-compose.yml` test — last remaining Phase 4 item after this.

## Test plan

- [x] Fixture verified end-to-end locally against the real published image (see above).
- [x] `actionlint`, `shellcheck`, `docker compose config`, `jq` all pass.
- [x] Confirm `component-sniproxy` passes in real CI on this PR.