### PR TITLE
CI: test the repository docker-compose.yml with candidate images

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -373,6 +373,81 @@ jobs:
         working-directory: tests/sniproxy
         run: docker compose down -v || true
 
+  # Validates the repository's own user-facing docker-compose.yml -- the file
+  # real users follow via README.md -- actually starts and functions with the
+  # tested candidate images, via a CI-only override (tests/repo-compose/) that
+  # substitutes candidate digests and non-conflicting host ports. Never edits
+  # docker-compose.yml itself.
+  component-repo-compose:
+    needs: build-candidates
+    if: success() && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      DNS_IMAGE: ghcr.io/${{ github.repository_owner }}/lancache-dns@${{ needs.build-candidates.outputs.dns_digest }}
+      MONOLITHIC_IMAGE: ghcr.io/${{ github.repository_owner }}/lancache-monolithic@${{ needs.build-candidates.outputs.monolithic_digest }}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Write CI-safe .env values
+        run: |
+          set -euo pipefail
+          # lancache-dns rejects loopback addresses for LANCACHE_IP/DNS_BIND_IP,
+          # so a real interface IP is needed rather than 127.0.0.1.
+          runner_ip=$(ip -4 route get 1.1.1.1 | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1); exit}')
+          mkdir -p repo-compose-cache/cache repo-compose-cache/logs
+          chmod 777 repo-compose-cache/cache repo-compose-cache/logs
+          cat > .env << EOF
+          USE_GENERIC_CACHE=true
+          LANCACHE_IP=${runner_ip}
+          DNS_BIND_IP=${runner_ip}
+          UPSTREAM_DNS=8.8.8.8
+          CACHE_ROOT=${PWD}/repo-compose-cache
+          CACHE_DISK_SIZE=1000000m
+          CACHE_INDEX_SIZE=500m
+          CACHE_MAX_AGE=3650d
+          TZ=Europe/London
+          EOF
+          echo "RUNNER_IP=${runner_ip}" >> "$GITHUB_ENV"
+
+      - name: Start the documented Compose installation with candidate images
+        run: |
+          docker compose -f docker-compose.yml -f tests/repo-compose/ci-override.yml up -d
+
+      - name: Wait for functional DNS and HTTP
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            dns_result=$(docker compose -f docker-compose.yml -f tests/repo-compose/ci-override.yml \
+              exec -T dns nslookup lancache.steamcontent.com 127.0.0.1 2>/dev/null \
+              | grep "^Address:" | tail -1 | awk '{print $2}' | tr -d '\r' || true)
+            http_code=$(curl -s -o /dev/null -w '%{http_code}' -H 'Host: lancache.steamcontent.com' \
+              "http://127.0.0.1:15380/lancache-heartbeat" || true)
+            echo "dns=${dns_result:-<none>} http=${http_code:-<none>}"
+            if [ "${dns_result}" = "${RUNNER_IP}" ] && { [ "${http_code}" = "200" ] || [ "${http_code}" = "204" ]; }; then
+              echo "Documented Compose installation is functional with candidate images"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::documented Compose installation did not become functional in time"
+          exit 1
+
+      - name: Collect diagnostics
+        if: failure()
+        run: |
+          docker compose -f docker-compose.yml -f tests/repo-compose/ci-override.yml ps
+          docker compose -f docker-compose.yml -f tests/repo-compose/ci-override.yml logs
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker compose -f docker-compose.yml -f tests/repo-compose/ci-override.yml down -v || true
+          rm -rf repo-compose-cache .env || true
+
   # Exercises actions/upload-artifact and actions/download-artifact directly so a
   # Renovate PR bumping either action runs the exact dependency it changes.
   artifact-contracts:
@@ -545,6 +620,7 @@ jobs:
       - functional-arm64
       - component-generic
       - component-sniproxy
+      - component-repo-compose
       - artifact-contracts
       - fork-build-test
     if: always()
@@ -562,11 +638,12 @@ jobs:
           ARM64_RESULT: ${{ needs.functional-arm64.result }}
           GENERIC_RESULT: ${{ needs.component-generic.result }}
           SNIPROXY_RESULT: ${{ needs.component-sniproxy.result }}
+          REPO_COMPOSE_RESULT: ${{ needs.component-repo-compose.result }}
           ARTIFACT_RESULT: ${{ needs.artifact-contracts.result }}
           FORK_RESULT: ${{ needs.fork-build-test.result }}
         run: |
           set -euo pipefail
-          echo "is_fork=$IS_FORK validate=$VALIDATE_RESULT build=$BUILD_RESULT amd64=$AMD64_RESULT arm64=$ARM64_RESULT generic=$GENERIC_RESULT sniproxy=$SNIPROXY_RESULT artifact=$ARTIFACT_RESULT fork=$FORK_RESULT"
+          echo "is_fork=$IS_FORK validate=$VALIDATE_RESULT build=$BUILD_RESULT amd64=$AMD64_RESULT arm64=$ARM64_RESULT generic=$GENERIC_RESULT sniproxy=$SNIPROXY_RESULT repo_compose=$REPO_COMPOSE_RESULT artifact=$ARTIFACT_RESULT fork=$FORK_RESULT"
 
           if [ "$VALIDATE_RESULT" != "success" ]; then
             echo "::error::validate did not succeed ($VALIDATE_RESULT)"
@@ -580,7 +657,7 @@ jobs:
             fi
           else
             failed=0
-            for pair in "build-candidates:$BUILD_RESULT" "functional-amd64:$AMD64_RESULT" "functional-arm64:$ARM64_RESULT" "component-generic:$GENERIC_RESULT" "component-sniproxy:$SNIPROXY_RESULT" "artifact-contracts:$ARTIFACT_RESULT"; do
+            for pair in "build-candidates:$BUILD_RESULT" "functional-amd64:$AMD64_RESULT" "functional-arm64:$ARM64_RESULT" "component-generic:$GENERIC_RESULT" "component-sniproxy:$SNIPROXY_RESULT" "component-repo-compose:$REPO_COMPOSE_RESULT" "artifact-contracts:$ARTIFACT_RESULT"; do
               name="${pair%%:*}"
               result="${pair##*:}"
               if [ "$result" != "success" ]; then

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,6 +53,11 @@ jobs:
           SNIPROXY_IMAGE=placeholder \
             docker compose -f tests/sniproxy/docker-compose.yml config -q
 
+      - name: Validate repository docker-compose.yml with the CI override
+        run: |
+          DNS_IMAGE=placeholder MONOLITHIC_IMAGE=placeholder \
+            docker compose -f docker-compose.yml -f tests/repo-compose/ci-override.yml config -q
+
       - name: ShellCheck extracted test scripts
         run: |
           mapfile -d '' -t scripts < <(find tests scripts -type f -name '*.sh' -print0)

--- a/TESTING.md
+++ b/TESTING.md
@@ -43,6 +43,7 @@ build-candidates (same-repo PRs) --or-- fork-build-test (external fork PRs)
    +--> functional-arm64
    +--> component-generic
    +--> component-sniproxy
+   +--> component-repo-compose
    +--> artifact-contracts
               |
            ci-gate
@@ -50,7 +51,7 @@ build-candidates (same-repo PRs) --or-- fork-build-test (external fork PRs)
 
 `ci-gate` is the single stable, non-matrix check intended to be required in branch protection. It explicitly evaluates the result of every job above (including the same-repo/fork branch that actually ran) and fails if any required job failed, was cancelled, or was skipped when it should have run.
 
-**Same-repository PRs** (including Renovate): `build-candidates` builds all six images once per revision, pushes them to GHCR tagged `pr-<number>-<head-sha>` (immutable — a new commit gets a new tag rather than overwriting the previous revision's images), and captures each image's manifest digest as a job output. `functional-amd64`, `functional-arm64`, `component-generic`, `component-sniproxy`, and `artifact-contracts` all consume those exact digests, so updating a PR cannot cause a test to run against a stale image.
+**Same-repository PRs** (including Renovate): `build-candidates` builds all six images once per revision, pushes them to GHCR tagged `pr-<number>-<head-sha>` (immutable — a new commit gets a new tag rather than overwriting the previous revision's images), and captures each image's manifest digest as a job output. `functional-amd64`, `functional-arm64`, `component-generic`, `component-sniproxy`, `component-repo-compose`, and `artifact-contracts` all consume those exact digests, so updating a PR cannot cause a test to run against a stale image.
 
 **External fork PRs**: GitHub always issues a read-only `GITHUB_TOKEN` for `pull_request` runs from forks, regardless of the `permissions:` declared in the workflow, so `build-candidates` cannot push to GHCR for fork PRs. `fork-build-test` runs instead: a local, AMD64-only build (`--load`, no `--push`, no registry login) with a basic heartbeat smoke test. Fork PRs do not get ARM64 or artifact-contract coverage.
 
@@ -91,7 +92,9 @@ Every image is built for AMD64, ARM64, and ARMv7 (`build-candidates.yml`), which
 
 `component-sniproxy` (`tests/sniproxy/`) verifies "TLS pass-through reaches a controlled origin": a small self-signed-TLS nginx origin is registered under a network alias (`sniproxy-test.internal`); a client container first confirms the origin serves known content directly (sanity check that the fixture itself is correct), then uses `curl --connect-to sniproxy-test.internal:443:sniproxy:443` to force the same request's *TCP connection* through the candidate sniproxy container while keeping the *SNI hostname* unchanged. sniproxy resolves that hostname via Docker's embedded DNS (`UPSTREAM_DNS=127.0.0.11`) and passes the TLS bytes straight through to the origin without terminating TLS itself. The response must match the origin's known content exactly, proving the pass-through actually reached the intended destination rather than erroring, hanging, or connecting elsewhere.
 
-> **Known gap (tracked for follow-up PRs)**: `sniproxy` has no dedicated runtime test at all today (only a manifest-platform check), and no image has ARMv7 or ARM64 (for `generic`) runtime coverage yet — ARMv7 QEMU emulation is slow enough that it's planned for the release-gate's deeper suite rather than every PR, per the plan's "fast required suite, deeper scheduled suite" principle. The repository's own `docker-compose.yml` is not yet tested against candidate images either.
+`component-repo-compose` validates the repository's own user-facing `docker-compose.yml` — the file real users follow via `README.md` — rather than only the test-specific fixtures under `tests/`. It layers a CI-only override (`tests/repo-compose/ci-override.yml`, using the Compose Specification's `!override` merge tag so host ports are fully replaced rather than merged) on top of the real file to substitute the tested candidate digests and non-conflicting host ports (`15353`/`15380`/`15443` instead of `53`/`80`/`443`), writes a CI-safe `.env` (a real interface IP is required — `lancache-dns` rejects loopback addresses — detected via `ip -4 route get`), then asserts real DNS resolution and a working HTTP heartbeat through the started stack. `docker-compose.yml` itself is never edited.
+
+> **Known gap (tracked for follow-up PRs)**: no image has ARMv7 runtime coverage yet, and `generic`/`sniproxy` have no ARM64 coverage either — ARMv7 QEMU emulation is slow enough that it's planned for the release-gate's deeper suite rather than every PR, per the plan's "fast required suite, deeper scheduled suite" principle.
 
 ### 3. Release (`.github/workflows/release.yml`)
 

--- a/tests/repo-compose/ci-override.yml
+++ b/tests/repo-compose/ci-override.yml
@@ -1,0 +1,12 @@
+services:
+  dns:
+    image: ${DNS_IMAGE}
+    ports: !override
+      - "${DNS_BIND_IP}:15353:53/udp"
+      - "${DNS_BIND_IP}:15353:53/tcp"
+
+  monolithic:
+    image: ${MONOLITHIC_IMAGE}
+    ports: !override
+      - "15380:80/tcp"
+      - "15443:443/tcp"


### PR DESCRIPTION
## Summary

Final slice of Phase 4 (follows #50, #51, #52). Until now, nothing exercised the repository's own user-facing `docker-compose.yml` — the file real users actually follow via `README.md` (`git clone`, edit `.env`, `docker-compose up -d`) — at all. Adds `component-repo-compose` to `pr-ci.yml` (and to `ci-gate`'s required set).

### How it works

- `tests/repo-compose/ci-override.yml` layers on top of the real `docker-compose.yml` (which is **never edited**) to substitute the tested candidate digests and non-conflicting host ports (`15353`/`15380`/`15443` instead of `53`/`80`/`443`).
- The job writes a CI-safe `.env` in the ephemeral checkout — a real interface IP is required since `lancache-dns` rejects loopback addresses, detected via `ip -4 route get 1.1.1.1` (the same technique the old `test-scheduled-functionality.yml` used).
- Asserts real DNS resolution (a cache-domain name resolves to the runner's own IP) and a working HTTP heartbeat through the started stack, polling with a bounded retry loop.

### A real bug this caught while building it

Ports use the Compose Specification's `!override` merge tag. I initially wrote a plain list override, which I *assumed* would fully replace the base file's `ports:` — but Compose actually **merges/concatenates** plain sequence overrides with the base by default. Running it locally, both the original ports (`53`/`80`/`443`) *and* the override ports ended up bound simultaneously, defeating the "non-conflicting ports" goal entirely. Fixed with the `!override` tag, verified the generated config only contains the override ports afterward.

## Verified locally before wiring in

- The full fixture end-to-end against the real published `lancache-dns`/`lancache-monolithic` images: real DNS resolution and real HTTP heartbeat through the overridden ports.
- The ports-merging bug and its fix, by inspecting `docker compose config` output before and after adding `!override`.
- Restored the repository's tracked `.env` afterward with `git checkout -- .env` rather than manually reverting content, since I'd temporarily rewritten it for the local test.
- `actionlint`, `shellcheck`, `docker compose config` (on the override-layered file), `jq` all pass.

Also corrected a stale note in `TESTING.md` — it still described `sniproxy` as having no dedicated test, left over from before #52 added `component-sniproxy`.

## Not in this PR

- ARM64/ARMv7 coverage for the repo Compose test — AMD64 only, matching how the other component tests are scoped in this phase.

This closes out Phase 4 (architecture and component coverage) as scoped in the plan, aside from the ARMv7/ARM64 gaps already tracked in `TESTING.md`'s known-gaps notes for a later, dedicated pass.

## Test plan

- [x] Fixture verified end-to-end locally against the real published images (see above), including catching and fixing the ports-merge bug.
- [x] `actionlint`, `shellcheck`, `docker compose config`, `jq` all pass.
- [x] Confirm `component-repo-compose` passes in real CI on this PR.