### PR TITLE
CI: add advisory MegaLinter (Dockerfile/secrets/YAML/Python), fix 2 findings

### DIFF
--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -1,0 +1,51 @@
+name: MegaLinter
+
+# Advisory only, deliberately not part of ci-gate: this is meant to surface
+# findings (Dockerfile lint, secret scanning, YAML lint, Python typing) for
+# visibility, not to block merges. See .mega-linter.yml for why it's scoped
+# to a small linter whitelist instead of the whole cupcake flavor.
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: megalinter-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  megalinter:
+    name: MegaLinter
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: MegaLinter
+        id: ml
+        uses: oxsecurity/megalinter/flavors/cupcake@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc # v9.6.0
+        env:
+          # PRs lint only the diff against main (fast); manual runs check
+          # the whole codebase.
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'workflow_dispatch' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Archive MegaLinter report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: megalinter-reports
+          include-hidden-files: "true"
+          path: |
+            megalinter-reports
+            mega-linter.log
+          retention-days: 20

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -180,7 +180,7 @@ jobs:
             start_time=$(date +%s%N)
             result=$(nslookup $domain 127.0.0.1:5353 | grep "Address:" | tail -1 | awk '{print $2}')
             end_time=$(date +%s%N)
-            
+
             if [ "$result" = "127.0.0.1" ]; then
               query_time=$(( (end_time - start_time) / 1000000 ))
               total_time=$((total_time + query_time))
@@ -196,7 +196,7 @@ jobs:
             echo "📊 DNS Performance Summary:" >> $GITHUB_STEP_SUMMARY
             echo "- Successful queries: $successful_queries/${#test_domains[@]}" >> $GITHUB_STEP_SUMMARY
             echo "- Average resolution time: ${avg_time}ms" >> $GITHUB_STEP_SUMMARY
-            
+
             if [ $avg_time -lt 50 ]; then
               echo "✅ DNS performance is excellent (< 50ms)" >> $GITHUB_STEP_SUMMARY
             elif [ $avg_time -lt 100 ]; then
@@ -220,13 +220,13 @@ jobs:
       - name: Cache Performance Test
         run: |
           echo "Running cache performance tests..."
-           
+
            # Test cache miss vs cache hit performance
            test_files=("small-1kb.bin" "small-100kb.bin" "medium-1mb.bin")
-           
+
           for file in "${test_files[@]}"; do
             echo "Testing cache performance for $file..."
-            
+
             # Configure nginx to proxy to our test server for this file
             docker compose -f perf-compose.yml exec -T monolithic sh -c '
               mkdir -p /etc/nginx/sites-available/cache.conf.d/
@@ -238,26 +238,26 @@ jobs:
           EOF
               nginx -s reload
             '
-            
+
             # Test cache miss (first request)
             echo "Testing cache miss for $file..."
             miss_start=$(date +%s%N)
             curl -s -o /dev/null http://127.0.0.1:8080/$file
             miss_end=$(date +%s%N)
             miss_time=$(( (miss_end - miss_start) / 1000000 ))
-            
+
             # Small delay to ensure cache write completes
             sleep 1
-            
+
             # Test cache hit (second request)
             echo "Testing cache hit for $file..."
             hit_start=$(date +%s%N)
             curl -s -o /dev/null http://127.0.0.1:8080/$file
             hit_end=$(date +%s%N)
             hit_time=$(( (hit_end - hit_start) / 1000000 ))
-            
+
             improvement_ratio=$(echo "scale=2; $miss_time / $hit_time" | bc)
-            
+
             echo "📊 Cache Performance for $file:" >> $GITHUB_STEP_SUMMARY
             echo "- Cache miss: ${miss_time}ms" >> $GITHUB_STEP_SUMMARY
             echo "- Cache hit: ${hit_time}ms" >> $GITHUB_STEP_SUMMARY
@@ -315,7 +315,7 @@ jobs:
             requests_per_sec=$(grep "Requests per second" ab_results.txt | awk '{print $4}')
             mean_time=$(grep "Time per request.*mean" ab_results.txt | head -1 | awk '{print $4}')
             failed_requests=$(grep "Failed requests" ab_results.txt | awk '{print $3}')
-            
+
             echo "- Requests per second: $requests_per_sec" >> $GITHUB_STEP_SUMMARY
             echo "- Mean time per request: ${mean_time}ms" >> $GITHUB_STEP_SUMMARY
             echo "- Failed requests: $failed_requests" >> $GITHUB_STEP_SUMMARY

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,0 +1,21 @@
+# MegaLinter configuration. Deliberately scoped to a small whitelist rather
+# than a whole flavor's descriptor groups: the cupcake flavor's IaC scanners
+# (checkov, kics) mostly flag disposable CI test fixtures for missing
+# production hardening (no USER, no healthcheck, privileged ports our real
+# docker-compose.yml legitimately needs), and its formatters (shfmt, black,
+# prettier, markdown-table-formatter) are style opinions rather than
+# correctness checks. See TESTING.md for the reasoning behind each inclusion.
+ENABLE_LINTERS:
+  - DOCKERFILE_HADOLINT
+  - REPOSITORY_GITLEAKS
+  - REPOSITORY_SECRETLINT
+  - REPOSITORY_TRUFFLEHOG
+  - YAML_YAMLLINT
+  - PYTHON_MYPY
+  - PYTHON_PYRIGHT
+
+APPLY_FIXES: none
+GITHUB_COMMENT_REPORTER: false
+GITHUB_STATUS_REPORTER: false
+UPDATED_SOURCES_REPORTER: false
+FLAVOR_SUGGESTIONS: false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,11 @@
+extends: default
+rules:
+  # GitHub Actions workflows conventionally omit "---" and use a bare `on:`
+  # key, which trips these two default rules on almost every real workflow.
+  document-start: disable
+  truthy: disable
+  # A style opinion, not a correctness check -- long `run:` commands and
+  # conditional expressions are normal in workflow YAML and often clearer
+  # unwrapped. Consistent with not enabling MegaLinter's other formatters
+  # (see .mega-linter.yml).
+  line-length: disable

--- a/TESTING.md
+++ b/TESTING.md
@@ -4,12 +4,13 @@ This document describes the comprehensive testing infrastructure for the LanCach
 
 ## Overview
 
-The testing system consists of four workflows that provide comprehensive validation:
+The testing system consists of five workflows that provide comprehensive validation:
 
 1. **Validate** - Static validation of workflows, Compose, and Renovate config
 2. **PR CI** - Validates every pull request and gates merges via `ci-gate`
 3. **Release** - Builds, tests, and promotes release images via `release-gate`
-4. **Performance Tests** - Manual performance and load testing
+4. **MegaLinter** - Advisory-only Dockerfile/secret/YAML/Python linting, not part of `ci-gate`
+5. **Performance Tests** - Manual performance and load testing
 
 Candidate builds are shared: `build-candidates.yml` is a reusable workflow called by both **PR CI** and **Release**, so the same build logic (and its safety checks) runs regardless of which pipeline triggered it.
 
@@ -131,7 +132,22 @@ build-candidates (reusable, shared with pr-ci.yml)
 
 - ❌ Failure to resolve upstream SHAs, build candidates, pass the functional test, or pass the security scan blocks promotion entirely — no tag changes.
 
-### 4. Performance Tests (`.github/workflows/performance-tests.yml`)
+### 4. MegaLinter (`.github/workflows/megalinter.yml`)
+
+**Triggers**: Every pull request (lints only the diff against `main`), and manual `workflow_dispatch` (lints the whole codebase).
+
+Advisory only — deliberately **not** part of `ci-gate`, so a finding here never blocks a merge. No PR comments and no automatic fixes (`APPLY_FIXES: none`, `GITHUB_COMMENT_REPORTER: false`); results are visible via the job's own log and an uploaded `megalinter-reports` artifact.
+
+Uses the `cupcake` flavor (`oxsecurity/megalinter/flavors/cupcake`), but scoped via `.mega-linter.yml` to a small linter whitelist rather than everything cupcake bundles:
+
+- `DOCKERFILE_HADOLINT` — the actual gap this closes; none of the Dockerfiles under `tests/` had any linting before.
+- `REPOSITORY_GITLEAKS`, `REPOSITORY_SECRETLINT`, `REPOSITORY_TRUFFLEHOG` — three independent secret scanners.
+- `YAML_YAMLLINT` — general YAML lint beyond actionlint's GitHub-Actions-specific syntax checks (see `.yamllint.yml` for the two rules disabled: `document-start`/`truthy`, which fire on nearly every real GitHub Actions workflow, plus `line-length`, a style opinion rather than a correctness check).
+- `PYTHON_MYPY`, `PYTHON_PYRIGHT` — type checking for `tests/cache-integration/origin/server.py` and `generate-fixture.py`.
+
+Explicitly **not** enabled: cupcake's IaC scanners (`checkov`, `kics`) mostly flag disposable CI test fixtures for missing production-grade hardening (no `USER`, no healthcheck, privileged ports the repository's real `docker-compose.yml` legitimately needs) rather than real problems, and its formatters (`shfmt`, `black`, `prettier`, `markdown-table-formatter`) are style opinions, not correctness checks — consistent with not enabling formatters elsewhere in this repo's tooling.
+
+### 5. Performance Tests (`.github/workflows/performance-tests.yml`)
 
 **Triggers**: Manual only (`workflow_dispatch`)
 

--- a/tests/cache-integration/origin/server.py
+++ b/tests/cache-integration/origin/server.py
@@ -25,7 +25,7 @@ SLOW_DELAY_SECONDS = float(os.environ.get("SLOW_DELAY_SECONDS", "1.5"))
 RANGE_RE = re.compile(r"^bytes=(\d*)-(\d*)$")
 
 _lock = threading.Lock()
-_hits = {}
+_hits: dict[str, int] = {}
 
 
 def _record_hit(path):
@@ -36,7 +36,7 @@ def _record_hit(path):
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
-    def log_message(self, fmt, *args):
+    def log_message(self, format, *args):
         pass  # keep container logs quiet; /stats is the source of truth
 
     def do_GET(self):


### PR DESCRIPTION
## Summary

Investigated adding MegaLinter, verified locally against the real `oxsecurity/megalinter-cupcake` Docker image before writing any CI config, and fixed the two real things it found along the way.

### What it found, and what I did with each

Ran the `cupcake` flavor against the whole repo with no scoping first, to see what's actually useful vs. noisy for this repo:

- **`hadolint`** (Dockerfile linting — the actual gap this closes) ran clean. Enabled.
- **3 independent secret scanners** (`gitleaks`, `secretlint`, `trufflehog`) all clean. Enabled — a real new safety net.
- **`yamllint`** caught **11 lines of pre-existing trailing whitespace in `performance-tests.yml`** — genuinely useful, since our own `git diff --check` only checks the diff of a *change*, never whitespace already sitting in an untouched file. Fixed, and enabled.
- **`mypy`/`pyright`** found 2 small legitimate typing issues in `tests/cache-integration/origin/server.py`. Fixed, and enabled.
- **`checkov`/`kics`** (46+ combined findings) mostly flag disposable CI test fixtures for missing production-grade hardening — no `USER`, no healthcheck, privileged ports the real `docker-compose.yml` legitimately needs. Not enabled.
- **Formatters** (`shfmt`, `black`, `prettier`×3, `markdown-table-formatter`) are style opinions, not correctness checks — consistent with not running formatters elsewhere in this repo. Not enabled.
- **`yamllint`'s `document-start`/`truthy`** fire on nearly every real GitHub Actions workflow (yamllint's defaults aren't GHA-aware) — relaxed via `.yamllint.yml`.
- **`yamllint`'s `line-length`** produced 260 findings across normal-length `run:` blocks and conditionals — a style opinion, not a real problem. Also relaxed.

### A mistake caught before it shipped

My first attempt at the trailing-whitespace fix used `sed -i '' -E 's/[ \t]+$//'` on macOS. BSD sed doesn't treat `\t` as an escape inside a bracket expression, so `[ \t]` matched the literal characters `space`, `\`, and `t` — silently eating the trailing "t" from words like "latest" → "lates", "test" → "tes", "start" → "star" throughout the file. Caught via `diff` before committing, reverted with `git checkout --`, and redone with the portable `[[:space:]]` POSIX class.

### What's new

- `.github/workflows/megalinter.yml`: runs on every PR (diff-only) and manual dispatch (whole codebase). **Advisory only, not part of `ci-gate`** — a finding here never blocks a merge. No PR comments, no auto-fixes.
- `.mega-linter.yml`: scopes `cupcake` down to `DOCKERFILE_HADOLINT`, `REPOSITORY_GITLEAKS`/`SECRETLINT`/`TRUFFLEHOG`, `YAML_YAMLLINT`, `PYTHON_MYPY`/`PYRIGHT` only.
- `.yamllint.yml`: disables `document-start`, `truthy`, `line-length`.

## Verified locally before wiring in

- Ran the actual `oxsecurity/megalinter-cupcake:v9` image against the repo using **only the committed config files** (no command-line overrides) after applying both fixes: all 7 enabled linters pass clean.
- Confirmed the fixed `performance-tests.yml` has the same line count and no corrupted words (diffed against the pre-fix version).
- `actionlint`, `docker compose config`, `jq`, and a YAML-parse check on the two new config files all pass.

## Test plan

- [x] Local MegaLinter run (committed config only) passes clean — see above.
- [x] `actionlint` and other existing validation pass.
- [ ] Confirm the `MegaLinter` job runs and passes on this PR in real CI (diff-only mode, since it's a `pull_request` trigger).